### PR TITLE
Adds an OS X Makefile

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -1,0 +1,8 @@
+include Makefile
+
+CC=clang++
+#CXXFLAGS=-stdlib=libstdc++
+#CPPFAGS=-stdlib=libstdc++
+COPTS=-fPIC -O2 -m64 -Wall -stdlib=libc++ -std=c++11
+LDOPTS=-shared -Wl,-install_name,$(LIBRARY)
+INSTDIR=$(PWD)/mac

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -4,5 +4,5 @@ CC=clang++
 #CXXFLAGS=-stdlib=libstdc++
 #CPPFAGS=-stdlib=libstdc++
 COPTS=-fPIC -O2 -m64 -Wall -stdlib=libc++ -std=c++11
-LDOPTS=-shared -Wl,-install_name,$(LIBRARY)
+LDOPTS=-dynamiclib -Wl,-install_name,@rpath/$(LIBRARY)
 INSTDIR=$(PWD)/mac


### PR DESCRIPTION
This PR adds an OS X Makefile.  

I have done this in order to support builds of the CSM via [conda-forge](https://github.com/conda-forge/staged-recipes/pull/2695).  This is a widely used python package management environment that supports linking Python with C (C++) languages.

I have tested this on OS X 10.12.1 by building the shared library and accessing via our [CyCSM Wrapper](https://github.com/USGS-Astrogeology/CSM-CyCSM).