### PR TITLE
Link major lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ TAR=tar
 
 LD=$(CC)
 
+# compute the "major" version from the library version
+MAJORLIBVERSION=$(word 1,$(subst ., ,$(LIBVERSION)))
+
 %.o: %.cpp
 	$(CC) -c $(COPTS) $< -o $@
 
@@ -36,6 +39,7 @@ install::
 	$(MKDIR) -p $(INSTDIR)/lib
 	$(CP) $(LIBRARY) $(INSTDIR)/lib
 	$(RM) $(INSTDIR)/lib/$(LIBNAME).so && $(LN) $(LIBRARY) $(INSTDIR)/lib/$(LIBNAME).so
+	@if [ "$(LIBVERSION)" != "$(MAJORLIBVERSION)" ]; then $(RM) $(INSTDIR)/lib/$(LIBNAME).so.$(MAJORLIBVERSION) && $(LN) $(LIBRARY) $(INSTDIR)/lib/$(LIBNAME).so.$(MAJORLIBVERSION); fi
 	$(MKDIR) -p $(INSTDIR)/include/csm
 	$(CP) $(HEADERS) $(INSTDIR)/include/csm
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ LD=$(CC)
 
 # compute the "major" version from the library version
 MAJORLIBVERSION=$(word 1,$(subst ., ,$(LIBVERSION)))
+SONAME=$(LIBNAME).so.$(MAJORLIBVERSION)
 
 %.o: %.cpp
 	$(CC) -c $(COPTS) $< -o $@

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -2,5 +2,5 @@ include Makefile
 
 CC=g++
 COPTS=-fPIC -O2 -m32 -Wall
-LDOPTS=-shared -Wl,-soname,$(LIBRARY)
+LDOPTS=-shared -Wl,-soname,$(SONAME)
 INSTDIR=$(PWD)/linux

--- a/Makefile.linux64
+++ b/Makefile.linux64
@@ -2,5 +2,5 @@ include Makefile
 
 CC=g++
 COPTS=-fPIC -O2 -m64 -Wall
-LDOPTS=-shared -Wl,-soname,$(LIBRARY)
+LDOPTS=-shared -Wl,-soname,$(SONAME)
 INSTDIR=$(PWD)/linux64

--- a/Makefile.linuxIA64
+++ b/Makefile.linuxIA64
@@ -2,5 +2,5 @@ include Makefile
 
 CC=g++
 COPTS=-fPIC -O3
-LDOPTS=-shared -Wl,-soname,$(LIBRARY)
+LDOPTS=-shared -Wl,-soname,$(SONAME)
 INSTDIR=$(PWD)/linux-ia64

--- a/Makefile.solaris
+++ b/Makefile.solaris
@@ -2,5 +2,5 @@ include Makefile
 
 CC=CC-12-p1
 COPTS=-KPIC -xtarget=ultra3 -xarch=sparcvis2 -xO3 -m32
-LDOPTS=-G -h $(LIBRARY)
+LDOPTS=-G -h $(SONAME)
 INSTDIR=$(PWD)/solaris

--- a/Makefile.solaris-stlport
+++ b/Makefile.solaris-stlport
@@ -2,5 +2,5 @@ include Makefile
 
 CC=CC-12-p1
 COPTS=-KPIC -xtarget=ultra3 -xarch=sparcvis2 -xO3 -m32 -library=stlport4,Crun
-LDOPTS=-G -h $(LIBRARY)
+LDOPTS=-G -h $(SONAME)
 INSTDIR=$(PWD)/solaris_stlport

--- a/Makefile.solaris64
+++ b/Makefile.solaris64
@@ -2,5 +2,5 @@ include Makefile
 
 CC=CC-12-p1
 COPTS=-KPIC -xarch=sparcvis2 -xO3 -m64
-LDOPTS=-G -h $(LIBRARY)
+LDOPTS=-G -h $(SONAME)
 INSTDIR=$(PWD)/solaris64

--- a/Makefile.solaris64-stlport
+++ b/Makefile.solaris64-stlport
@@ -2,5 +2,5 @@ include Makefile
 
 CC=CC-12-p1
 COPTS=-KPIC -xarch=sparcvis2 -xO3 -m64 -library=stlport4,Crun
-LDOPTS=-G -h $(LIBRARY)
+LDOPTS=-G -h $(SONAME)
 INSTDIR=$(PWD)/solaris64_stlport


### PR DESCRIPTION
Compute the "major" library name and use that as the SONAME for the libraries built on Solaris and Linux.