### PR TITLE
Correlation model updates

### DIFF
--- a/CorrelationModel.cpp
+++ b/CorrelationModel.cpp
@@ -38,11 +38,11 @@ CorrelationModel::CorrelationModel(const std::string& format,
 {
    if (numCPGroups)
    {
-      setNumCorrelationGroups(numCPGroups);
+      setNumCorrelationParameterGroups(numCPGroups);
    }
 }
 
-void CorrelationModel::setNumCorrelationGroups(size_t numCPGroups)
+void CorrelationModel::setNumCorrelationParameterGroups(size_t numCPGroups)
 {
    if (numCPGroups)
    {

--- a/CorrelationModel.cpp
+++ b/CorrelationModel.cpp
@@ -16,7 +16,7 @@
 //     -----------   ------   -------
 //     18-Feb-2013   JPK      Initial Coding
 //     20-Sep-2019   JPK      Added setFormat() and
-//                            setNumCorrelationGroups()
+//                            setNumCorrelationParameterGroups()
 //
 //    NOTES:
 //     Refer to CorrelationModel.h for more information.

--- a/CorrelationModel.cpp
+++ b/CorrelationModel.cpp
@@ -15,6 +15,8 @@
 //     Date          Author   Comment
 //     -----------   ------   -------
 //     18-Feb-2013   JPK      Initial Coding
+//     20-Sep-2019   JPK      Added setFormat() and
+//                            setNumCorrelationGroups()
 //
 //    NOTES:
 //     Refer to CorrelationModel.h for more information.
@@ -36,8 +38,25 @@ CorrelationModel::CorrelationModel(const std::string& format,
 {
    if (numCPGroups)
    {
-      theDecorrelationEventTimes.resize(numCPGroups,"");
+      setNumCorrelationGroups(numCPGroups);
    }
+}
+
+void CorrelationModel::setNumCorrelationGroups(size_t numCPGroups)
+{
+   if (numCPGroups)
+   {
+     theDecorrelationEventTimes.resize(numCPGroups,"");
+   }
+   else
+   {
+      theDecorrelationEventTimes.clear();
+   }
+}
+
+void CorrelationModel::setFormat(const std::string& format)
+{
+   theFormat = format;
 }
 
 const std::string&

--- a/CorrelationModel.h
+++ b/CorrelationModel.h
@@ -29,7 +29,7 @@
 //                            setDecorrelationEventTime().  Implemented
 //                            getNumCorrelationParameterGroups().
 //     20-Sep-2019   JPK      Added setFormat() and
-//                            setNumCorrelationGroups()
+//                            setNumCorrelationParameterGroups()
 //
 //    NOTES:
 //
@@ -140,7 +140,7 @@ protected:
 
    void setFormat(const std::string& format);
 
-   void setNumCorrelationGroups(size_t numCorrGroups);
+   void setNumCorrelationParameterGroups(size_t numCorrGroups);
    
  private:
    CorrelationModel()

--- a/CorrelationModel.h
+++ b/CorrelationModel.h
@@ -28,6 +28,8 @@
 //     18-Feb-2013   JPK      Added getDecorrelationEventTime() and
 //                            setDecorrelationEventTime().  Implemented
 //                            getNumCorrelationParameterGroups().
+//     20-Sep-2019   JPK      Added setFormat() and
+//                            setNumCorrelationGroups()
 //
 //    NOTES:
 //
@@ -135,6 +137,10 @@ protected:
       
    CorrelationModel(const std::string& format,
                     size_t numCPGroups);
+
+   void setFormat(const std::string& format);
+
+   void setNumCorrelationGroups(size_t numCorrGroups);
    
  private:
    CorrelationModel()


### PR DESCRIPTION
The CorrelationModel class has two private data members (theDecorrelationEventTimes , theFormat).  Ideally these should have been protected, but in order to keep compatibility with current API, protected "set" methods for these were added.   This allows "delayed" setting of these values, should they not be available at construct time.