### PR TITLE
suppress major and minor as macros

### DIFF
--- a/Version.h
+++ b/Version.h
@@ -20,6 +20,7 @@
 //     30-Oct-2012   SCM      Added version() accessors.
 //     30-Oct-2012   SCM      Renamed to Version.h
 //     17-Dec-2012   BAH      Documentation updates.
+//     15-Sep-2020   bradh    Undef major / minor macros from <sys/types.h>
 //
 //    NOTES:
 //
@@ -34,6 +35,12 @@
 #include <iosfwd>
 #include <vector>
 #include <sstream>
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
 
 namespace csm
 {


### PR DESCRIPTION
Resolves the case where `major` and `minor` are C macros which get dragged in via some C++ system headers, which leads to:
```
g++ -c -fPIC -O2 -m64 -Wall Version.cpp -o Version.o
In file included from Version.cpp:26:0:
Version.h:80:13: warning: In the GNU C Library, "major" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "major", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "major", you should undefine it after including <sys/types.h>.
    int major() const { return version(0); }
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                                                                                                                         
In file included from Version.cpp:26:0:
Version.h:84:13: warning: In the GNU C Library, "minor" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "minor", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "minor", you should undefine it after including <sys/types.h>.
    int minor() const { return version(1); }
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                            
```